### PR TITLE
Fix/master/cache jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,147 @@
 # nginx_introspect
 NGINX module that introspects access tokens according to RFC 7662
 
+## About
+This module, when enabled, filters incoming requests, denying access to those which do NOT have a valid `Authorization: Bearer` header. From this header, the `access_token` is exctracted and introspected using the configured endpoint. Curity replies to this request according to RFC 7662. For an active _access_token_, the body of Curity's response is a JSON which contains the JWT that replaces the _access_token_ in the header of the request forwarded to the backend. In case of a not active _access_token_, 401 Unauthorized is returned.
 
-> WARNING!
-> This module is still in development. Use it at your own risk!
+## Configuration directives
+access_token_to_jwt
+-------------------
+* **syntax**: `access_token_to_jwt on|off`
+* **default**: `off`
+* **context**: `location`
+
+Enable or disable the module.
+
+access_token_to_jwt_base64encoded_client_credentials
+-------------------
+* **syntax**: `access_token_to_jwt_base64encoded_client_credentials <string>`
+* **default**: 	`—`
+* **context**: `location`
+
+The base64 encoded string `client_id:client_secret` of the OAuth client which will be used for introspection.
+
+access_token_to_jwt_introspection_endpoint
+-------------------
+* **syntax**: `access_token_to_jwt_introspection_endpoint <string>`
+* **default**: 	`—`
+* **context**: `location`
+ 
+The name of the location that proxies requests to Curity. Note that this location needs to be in the same server as the one refering to it using this directive.
+
+
+
+## Sample configuration
+
+
+### Simple configuration (same server)
+
+        server {
+            location /api {
+                proxy_pass         https://example.com/api;
+                access_token_to_jwt on;
+                access_token_to_jwt_base64encoded_client_credentials "Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=";
+                access_token_to_jwt_introspection_endpoint curity;
+            }
+            
+            location curity {
+                proxy_pass "https://curity.example.com/oauth/v2/introspection";
+                proxy_set_header content-type "application/x-www-form-urlencoded";
+            }
+        }
+### Complex configuration (separate servers)
+        server {
+            server_name server1.example.com;n
+            location /api {
+                proxy_pass         https://example.com/api;
+                access_token_to_jwt on;
+                access_token_to_jwt_base64encoded_client_credentials "Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=";
+                access_token_to_jwt_introspection_endpoint curity;
+            }
+            
+            location curity {
+                proxy_pass "https://server2.example.com:8443/oauth/v2/introspection";
+                proxy_set_header content-type "application/x-www-form-urlencoded";
+            }
+        }
+        
+        server {
+            listen 8443;
+            server_name server2.example.com;
+            location / {
+                proxy_pass "https://curity.example.com";
+            }
+        }
+        
+### Advanced configuration (separate servers + cache)
+This module takes advantage of NGINX built-in _proxy_cache_ directive. In order to be able to cache the requests made to the introspection endpoint, except of the `proxy_cache_path` in http context and `proxy_cache` in location context, you have to add the following 3 directives in the location context of the introspection endpoint.
+
+- `proxy_cache_methods POST;` POST requests are not cached by default.
+- `proxy_cache_key $request_body;` The key of the cache is related to the _access_token_ sent in the original request. Different requests using the same _access_token_ reach the same cache.
+- `proxy_ignore_headers Set-Cookie;` NGINX will not cache the response if `Set-Cookie` header is not ignored.
+
+
+    http {
+        proxy_cache_path /path/to/cache/cache levels=1:2 keys_zone=my_cache:10m max_size=10g
+                         inactive=60m use_temp_path=off;
+       server {
+            server_name server1.example.com;
+            location /api {
+                proxy_pass         https://example.com/api;
+                access_token_to_jwt on;
+                access_token_to_jwt_base64encoded_client_credentials "Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=";
+                access_token_to_jwt_introspection_endpoint curity;
+            }
+            
+            location curity {
+                proxy_pass "https://server2.example.com:8443/oauth/v2/introspection";
+                proxy_set_header content-type "application/x-www-form-urlencoded";
+                
+                proxy_cache_methods POST;
+                proxy_cache my_cache;
+                proxy_cache_key $request_body;
+                proxy_ignore_headers Set-Cookie;
+            }
+        }
+        
+        server {
+            listen 8443;
+            server_name server2.example.com;
+            location / {
+                proxy_pass "https://curity.example.com";
+            }
+        }
+        
+    }   
+
+## Build    
+Download the NGINX source code from [nginx.org](<http://nginx.org/>) and then build with this module:
+
+        wget 'http://nginx.org/download/nginx-1.x.x.tar.gz'
+        tar -xzvf nginx-1.x.x.tar.gz
+        cd nginx-1.x.x/
+        ./configure --add-module=/path/to/ngx_http_access_token_to_jwt_module
+
+        make
+        make install
+
+If you use nginx >= 1.9.1 you can compile Dynamic module.
+
+        wget 'http://nginx.org/download/nginx-1.x.x.tar.gz'
+        tar -xzvf nginx-1.x.x.tar.gz
+        cd nginx-1.x.x/
+        ./configure --add-dynamic-module=/path/to/ngx_http_access_token_to_jwt_module
+
+        make
+        make install
+
+Then add `load_module modules/ngx_http_access_token_to_jwt_module.so;` to the top of your configuration file.
+
+## Testing and compatibility
+TBD
+## Status
+ This module is still in development. Use it at your own risk!
+
+## More Information
+For more information, please contact [Curity](http://curity.io).
+Copyright (C) 2016-2017 Curity AB. All rights reserved

--- a/README.md
+++ b/README.md
@@ -125,17 +125,6 @@ Download the NGINX source code from [nginx.org](<http://nginx.org/>) and then bu
         make
         make install
 
-If you use nginx >= 1.9.1 you can compile Dynamic module.
-
-        wget 'http://nginx.org/download/nginx-1.x.x.tar.gz'
-        tar -xzvf nginx-1.x.x.tar.gz
-        cd nginx-1.x.x/
-        ./configure --add-dynamic-module=/path/to/ngx_http_access_token_to_jwt_module
-
-        make
-        make install
-
-Then add `load_module modules/ngx_http_access_token_to_jwt_module.so;` to the top of your configuration file.
 
 ## Testing and compatibility
 TBD
@@ -144,4 +133,4 @@ TBD
 
 ## More Information
 For more information, please contact [Curity](http://curity.io).
-Copyright (C) 2016-2017 Curity AB. All rights reserved
+Copyright (C) 2017 Curity AB. All rights reserved

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,7 +9,9 @@ events { worker_connections 1024; }
 http {
  
     sendfile on;
- 
+    proxy_cache_path /path/to/cache/cache levels=1:2 keys_zone=my_cache:10m max_size=10g
+                         inactive=60m use_temp_path=off;
+
     server {
         listen 8080;
  
@@ -23,6 +25,11 @@ http {
         location curity {
             proxy_pass "http://localhost:8443/introspection-jwt";
             proxy_set_header content-type "application/x-www-form-urlencoded";
+
+            proxy_cache my_cache;
+            proxy_cache_methods POST;
+            proxy_cache_key $request_body;
+            proxy_ignore_headers Set-Cookie;
         }
     }  
 }

--- a/ngx_http_access_token_to_jwt.c
+++ b/ngx_http_access_token_to_jwt.c
@@ -136,7 +136,7 @@ static ngx_int_t ngx_http_access_token_to_jwt_handler(ngx_http_request_t *reques
         ngx_log_error(NGX_LOG_WARN, request->connection->log, 0,
                       "Module not configured properly: missing client credential");
 
-        return NGX_ABORT;
+        return NGX_DECLINED;
     }
 
     if (module_location_config->introspection_endpoint.len == 0)
@@ -144,7 +144,7 @@ static ngx_int_t ngx_http_access_token_to_jwt_handler(ngx_http_request_t *reques
         ngx_log_debug0(NGX_LOG_WARN, request->connection->log, 0,
                        "Module not configured properly: missing introspection endpoint");
 
-        return NGX_ABORT;
+        return NGX_DECLINED;
     }
 
     ngx_http_access_token_to_jwt_ctx_t *module_context = ngx_http_get_module_ctx(request, ngx_http_access_token_to_jwt_module);

--- a/ngx_http_access_token_to_jwt.c
+++ b/ngx_http_access_token_to_jwt.c
@@ -336,7 +336,7 @@ static ngx_int_t ngx_http_access_token_to_jwt_request_done(ngx_http_request_t *r
     // body parsing
     char *jwt_start = ngx_strstr(request->upstream->buffer.start, "\"jwt\":\"");
 
-    if (jwt_start == NULL)
+    if (jwt_start == NULL || ((u_char *)jwt_start - request->upstream->buffer.start  > request->headers_out.content_length_n))
     {
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, request->connection->log, 0, "Failed to parse JSON response\n");
         module_context->done = 1;

--- a/ngx_http_access_token_to_jwt.c
+++ b/ngx_http_access_token_to_jwt.c
@@ -335,7 +335,7 @@ static ngx_int_t ngx_http_access_token_to_jwt_request_done(ngx_http_request_t *r
     // body parsing
     char *jwt_start = ngx_strstr(request->header_start, JWT_KEY);
 
-    if (jwt_start == NULL && request->cache && request->cache->buf && request->cache->valid_sec != 0)
+    if (jwt_start == NULL && request->cache && request->cache->buf && request->cache->valid_sec > 0)
     {
         ngx_read_file(&request->cache->file, request->cache->buf->pos, request->cache->length, 0);
         jwt_start = ngx_strstr(request->cache->buf->start + request->cache->body_start, JWT_KEY);

--- a/ngx_http_access_token_to_jwt.c
+++ b/ngx_http_access_token_to_jwt.c
@@ -335,7 +335,7 @@ static ngx_int_t ngx_http_access_token_to_jwt_request_done(ngx_http_request_t *r
     // body parsing
     char *jwt_start = ngx_strstr(request->header_start, JWT_KEY);
 
-    if (jwt_start == NULL && request->cache)
+    if (jwt_start == NULL && request->cache && request->cache->buf && request->cache->valid_sec != 0)
     {
         ngx_read_file(&request->cache->file, request->cache->buf->pos, request->cache->length, 0);
         jwt_start = ngx_strstr(request->cache->buf->start + request->cache->body_start, JWT_KEY);
@@ -347,7 +347,7 @@ static ngx_int_t ngx_http_access_token_to_jwt_request_done(ngx_http_request_t *r
         module_context->done = 1;
         module_context->status = NGX_HTTP_UNAUTHORIZED;
 
-        return NGX_ERROR;
+        return rc;
     }
 
     jwt_start += sizeof(JWT_KEY) - 1;
@@ -360,7 +360,7 @@ static ngx_int_t ngx_http_access_token_to_jwt_request_done(ngx_http_request_t *r
         module_context->done = 1;
         module_context->status = NGX_HTTP_UNAUTHORIZED;
 
-        return NGX_ERROR;
+        return rc;
     }
 
     module_context->jwt.len = jwt_end - jwt_start + BEARER_SIZE;
@@ -369,7 +369,7 @@ static ngx_int_t ngx_http_access_token_to_jwt_request_done(ngx_http_request_t *r
 
     if (module_context->jwt.data == NULL)
     {
-        return NGX_ERROR;
+        return rc;
     }
 
     void * jwt_pointer = ngx_copy(module_context->jwt.data, BEARER, BEARER_SIZE);


### PR DESCRIPTION
Configuration example of required directives that need to be set in order to cache the response received from Curity. 

` proxy_cache_key $request_body;` Sets the key for the cache to be `token=xyz` so that other requests which have the same _access_token_ can use the same response from Curity.

Nginx caching of the response respects the response headers.

